### PR TITLE
fix NavHost cannot find parameter

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,7 +9,7 @@ kotlin = "1.9.21"
 kotlinx-serialization = "1.6.2"
 maven-publish = "0.25.3"
 spotless = "6.23.3"
-precompose = "1.5.11"
+precompose = "1.6.0"
 
 [libraries]
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,7 +9,7 @@ kotlin = "1.9.21"
 kotlinx-serialization = "1.6.2"
 maven-publish = "0.25.3"
 spotless = "6.23.3"
-precompose = "1.5.10"
+precompose = "1.5.11"
 
 [libraries]
 

--- a/typesafe/src/commonMain/kotlin/tech/annexflow/precompose/navigation/typesafe/NavHost.kt
+++ b/typesafe/src/commonMain/kotlin/tech/annexflow/precompose/navigation/typesafe/NavHost.kt
@@ -25,7 +25,6 @@ import tech.annexflow.precompose.navigation.typesafe.internal.encodeToString
  * @param initialRoute the route for the start destination
  * @param navTransition navigation transition for the scenes in this [TypesafeNavHost]
  * @param swipeProperties properties of swipe back navigation
- * @param persistNavState whether to persist navigation state to the Saved State Registry, defaults to false
  * @param builder the builder used to construct the graph
  */
 @ExperimentalTypeSafeApi
@@ -36,7 +35,6 @@ inline fun <reified T : Route> TypesafeNavHost(
     initialRoute: T,
     navTransition: NavTransition = remember { NavTransition() },
     swipeProperties: SwipeProperties? = null,
-    persistNavState: Boolean = false,
     noinline builder: RouteBuilder.() -> Unit,
 ) {
     TypesafeNavHost(
@@ -46,7 +44,6 @@ inline fun <reified T : Route> TypesafeNavHost(
         serializer = serializer<T>(),
         navTransition = navTransition,
         swipeProperties = swipeProperties,
-        persistNavState = persistNavState,
         builder = builder
     )
 }
@@ -60,7 +57,6 @@ fun <T : Route> TypesafeNavHost(
     serializer: KSerializer<T>,
     navTransition: NavTransition = remember { NavTransition() },
     swipeProperties: SwipeProperties? = null,
-    persistNavState: Boolean = false,
     builder: RouteBuilder.() -> Unit,
 ) {
     NavHost(
@@ -69,7 +65,6 @@ fun <T : Route> TypesafeNavHost(
         initialRoute = initialRoute.encodeToString(serializer),
         navTransition = navTransition,
         swipeProperties = swipeProperties,
-        persistNavState = persistNavState,
         builder = builder
     )
 }


### PR DESCRIPTION
In Precompose 1.5.11 persistNavState parameter of NavHost was removed. This PR removes that parameter and updates to that latest Precompose (1.6.1)