### PR TITLE
added support for js targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 ![badge-iOS](https://img.shields.io/badge/Platform-iOS-lightgray)
 ![badge-JVM](https://img.shields.io/badge/Platform-JVM-orange)
 ![badge-macOS](https://img.shields.io/badge/Platform-macOS-purple)
+![badge-Web](https://img.shields.io/badge/Platform-Web-blue)
 
 ## PreCompose Navigation TypeSafe
 

--- a/sample/shared/build.gradle.kts
+++ b/sample/shared/build.gradle.kts
@@ -1,6 +1,8 @@
 import org.jetbrains.compose.desktop.application.dsl.TargetFormat
 import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
+import org.jetbrains.kotlin.gradle.ExperimentalWasmDsl
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.targets.js.webpack.KotlinWebpackConfig
 
 plugins {
     alias(libs.plugins.multiplatform)
@@ -13,6 +15,24 @@ plugins {
 @OptIn(ExperimentalKotlinGradlePluginApi::class)
 kotlin {
     kotlin.applyDefaultHierarchyTemplate()
+
+    @OptIn(ExperimentalWasmDsl::class)
+    wasmJs {
+        moduleName = "composeApp"
+        browser {
+            val projectDirPath = project.projectDir.path
+            commonWebpackConfig {
+                outputFileName = "composeApp.js"
+                devServer = (devServer ?: KotlinWebpackConfig.DevServer()).apply {
+                    static = (static ?: mutableListOf()).apply {
+                        // Serve sources to debug inside browser
+                        add(projectDirPath)
+                    }
+                }
+            }
+        }
+        binaries.executable()
+    }
 
     androidTarget {
         compilerOptions {

--- a/sample/shared/src/commonMain/kotlin/tech/annexflow/sample/navigation/AppNavigation.kt
+++ b/sample/shared/src/commonMain/kotlin/tech/annexflow/sample/navigation/AppNavigation.kt
@@ -9,7 +9,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.BasicAlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
@@ -121,7 +121,7 @@ internal fun AppNavigation() {
                 }
             }
             dialog<AppRoutes.Dialog> {
-                AlertDialog(
+                BasicAlertDialog(
                     onDismissRequest = navigator::goBack
                 ) {
                     Column(

--- a/sample/shared/src/wasmJsMain/kotlin/main.kt
+++ b/sample/shared/src/wasmJsMain/kotlin/main.kt
@@ -1,0 +1,11 @@
+import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.window.ComposeViewport
+import kotlinx.browser.document
+import tech.annexflow.sample.App
+
+@OptIn(ExperimentalComposeUiApi::class)
+fun main() {
+    ComposeViewport(document.body!!) {
+        App()
+    }
+}

--- a/sample/shared/src/wasmJsMain/resources/index.html
+++ b/sample/shared/src/wasmJsMain/resources/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>undecrover</title>
+    <link type="text/css" rel="stylesheet" href="styles.css">
+    <script type="application/javascript" src="composeApp.js"></script>
+</head>
+<body>
+</body>
+</html>

--- a/sample/shared/src/wasmJsMain/resources/styles.css
+++ b/sample/shared/src/wasmJsMain/resources/styles.css
@@ -1,0 +1,7 @@
+html, body {
+    width: 100%;
+    height: 100%;
+    margin: 0;
+    padding: 0;
+    overflow: hidden;
+}

--- a/typesafe/build.gradle.kts
+++ b/typesafe/build.gradle.kts
@@ -1,4 +1,5 @@
 import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
+import org.jetbrains.kotlin.gradle.ExperimentalWasmDsl
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
@@ -27,6 +28,14 @@ kotlin {
         }
     }
 
+    js(IR) {
+        browser()
+    }
+    @OptIn(ExperimentalWasmDsl::class)
+    wasmJs {
+        browser()
+        binaries.executable()
+    }
     macosArm64()
     macosX64()
 


### PR DESCRIPTION
hello again,

this PR adds support for js/wasm targets. 

`./gradlew :sample:shared:wasmJsRun`


Issues found:

` val currentEntry by navigator.currentEntry.collectAsStateWithLifecycle(null)`

is not collecting current entry, but for sure it's not related to this library, it is issue with precompose or with kmm implementation of 'collectAsStateWithLifecycle' I will be investigating thus further, but i think that this PR could be merged.


https://github.com/user-attachments/assets/02a2011e-009a-4bf7-8273-da340720ddc2

